### PR TITLE
Do not trigger scroll on hash change

### DIFF
--- a/src/ScrollBehaviorContainer.js
+++ b/src/ScrollBehaviorContainer.js
@@ -23,7 +23,7 @@ export default class ScrollBehaviorContainer extends React.Component {
     const { routerProps } = this.props;
     const prevRouterProps = prevProps.routerProps;
 
-    if(routerProps.location === prevRouterProps.location || (routerProps.location.hash !== prevRouterProps.location.hash && routerProps.location.pathname === prevRouterProps.location.pathname)) {
+    if (routerProps.location === prevRouterProps.location || (routerProps.location.hash !== prevRouterProps.location.hash && routerProps.location.pathname === prevRouterProps.location.pathname)) {
       return;
     }
 

--- a/src/ScrollBehaviorContainer.js
+++ b/src/ScrollBehaviorContainer.js
@@ -23,7 +23,7 @@ export default class ScrollBehaviorContainer extends React.Component {
     const { routerProps } = this.props;
     const prevRouterProps = prevProps.routerProps;
 
-    if (routerProps.location === prevRouterProps.location) {
+    if(routerProps.location === prevRouterProps.location || (routerProps.location.hash !== prevRouterProps.location.hash && routerProps.location.pathname === prevRouterProps.location.pathname)) {
       return;
     }
 


### PR DESCRIPTION
This doesn't look that pretty, I'm curious what you think. If you are on the same page path and the hash changes, it won't scroll to the top like it currently does.

Edit: this exceed the line length, so it is failing.