### PR TITLE
Add scroll behaviour for container elements

### DIFF
--- a/src/ScrollContainer.js
+++ b/src/ScrollContainer.js
@@ -1,0 +1,27 @@
+import { Component, PropTypes } from 'react';
+import { findDOMNode } from 'react-dom';
+import ScrollBehavior from 'scroll-behavior/lib/ScrollBehavior';
+
+export default class ScrollContainer extends Component {
+  static propTypes = {
+    scrollKey: PropTypes.string,
+    children: PropTypes.element,
+  };
+
+  static contextTypes = {
+    scrollBehavior: PropTypes.instanceOf(ScrollBehavior),
+  };
+
+  componentDidMount() {
+    const node = findDOMNode(this);
+    this.context.scrollBehavior.registerContainer(this.props.scrollKey, node);
+  }
+
+  componentWillUnmount() {
+    this.context.scrollBehavior.unregisterContainer(this.props.scrollKey);
+  }
+
+  render() {
+    return this.props.children;
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import ScrollBehaviorContainer from './ScrollBehaviorContainer';
+import ScrollContainer from './ScrollContainer';
 
 export default function useScroll(shouldUpdateScroll) {
   return {
@@ -14,3 +15,5 @@ export default function useScroll(shouldUpdateScroll) {
     ),
   };
 }
+
+export { ScrollContainer };


### PR DESCRIPTION
[_Dual of this PR on scroll-behavior_](https://github.com/taion/scroll-behavior/pull/86)

You can use the `ScrollContainer` component to wrap a scrollable element. The class will handle calling the new `registerContainer` and `unregisterContainer` methods on `scrollBehavior`. Under the hood the `scrollBehavior` instance is added to the React context, so this class can be used anywhere.

Example code:

```javascript
import { ScrollContainer } from 'react-router-scroll';

function SomeComponent() {
  return (
    <ScrollContainer scrollKey="someComponent">
      <div style={{ height: 200, overflow: 'auto' }}
        <div style={{ height: 500 }}></div>
      </div>
    </ScrollContainer>
  );
}
```