### PR TITLE
Add RR ^3.0.0 to peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0",
-    "react-router": "^2.3.0"
+    "react-router": "^2.3.0 || ^3.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",


### PR DESCRIPTION
react-router-scroll's been working fine for me with RR 3 and History API-based URLs (as opposed to hashes, if that matters). Just want to silence the peer dep warning.