### PR TITLE
Update README: add example for internal anchor use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,39 @@ The callback can return:
 - a truthy value to emulate the browser default scroll behavior
 
 ```js
+// simple example to only scroll when url pathname changes
+// this example ignore search or hash changes
 useScroll((prevRouterProps, { location }) => (
   prevRouterProps && location.pathname !== prevRouterProps.location.pathname
 ));
 
+// example to only scroll when complete url changes
+// (except for hash change - this example provide a natural feeling when you
+// use simple link to internal anchor (eg: a table of content that use hashes
+// inside a page))
+const shouldUpdateScroll = (prevRouterProps, routerProps)=> {
+  if (prevRouterProps) {
+    const prev = prevRouterProps.location
+    const curr = routerProps.location
+    // if "page" is the same we don't scroll
+    if (prev.pathname + prev.search === curr.pathname + curr.search) {
+      // except if hash is empty, because it should keep browser natural
+      // behavior if:
+      // - same url, without considering the hash
+      // - previous url contains a hash to an new url does not
+      // both cases are kind of a "back to top" scenario
+      if (curr.hash === "") {
+        return true
+      }
+
+      return false
+    }
+  }
+
+  return true
+}
+
+// example for routes specific props
 useScroll((prevRouterProps, { routes }) => {
   if (routes.some(route => route.ignoreScrollBehavior)) {
     return false;


### PR DESCRIPTION
I heavily tested this example here https://github.com/MoOx/phenomic/commit/010b4b384b6ba4ef7a5467481282a4de7138d065

[skip ci]

Ref https://github.com/taion/react-router-scroll/issues/37