### PR TITLE
Support for async transitions 

### DIFF
--- a/src/ScrollBehaviorContext.js
+++ b/src/ScrollBehaviorContext.js
@@ -19,12 +19,14 @@ class ScrollBehaviorContext extends React.Component {
     super(props, context);
 
     const { routerProps } = props;
-    const { router } = routerProps;
+    const { router, location } = routerProps;
+
+    this.location = location;
 
     this.scrollBehavior = new ScrollBehavior({
       addTransitionHook: router.listenBefore,
       stateStorage: new StateStorage(router),
-      getCurrentLocation: () => this.props.routerProps.location,
+      getCurrentLocation: () => this.location,
       shouldUpdateScroll: this.shouldUpdateScroll,
     });
 
@@ -46,6 +48,7 @@ class ScrollBehaviorContext extends React.Component {
     }
 
     updateScroll(() => {
+      this.location = routerProps.location;
       this.scrollBehavior.updateScroll(prevRouterProps, routerProps);
     });
   }

--- a/src/ScrollBehaviorContext.js
+++ b/src/ScrollBehaviorContext.js
@@ -5,6 +5,7 @@ import StateStorage from './StateStorage';
 
 const propTypes = {
   shouldUpdateScroll: React.PropTypes.func,
+  updateScroll: React.PropTypes.func,
   routerProps: React.PropTypes.object.isRequired,
   children: React.PropTypes.element.isRequired,
 };
@@ -37,14 +38,16 @@ class ScrollBehaviorContext extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { routerProps } = this.props;
+    const { routerProps, updateScroll } = this.props;
     const prevRouterProps = prevProps.routerProps;
 
     if (routerProps.location === prevRouterProps.location) {
       return;
     }
 
-    this.scrollBehavior.updateScroll(prevRouterProps, routerProps);
+    updateScroll(() => {
+      this.scrollBehavior.updateScroll(prevRouterProps, routerProps);
+    });
   }
 
   componentWillUnmount() {

--- a/src/useScroll.js
+++ b/src/useScroll.js
@@ -2,11 +2,20 @@ import React from 'react';
 
 import ScrollBehaviorContext from './ScrollBehaviorContext';
 
-export default function useScroll(shouldUpdateScroll) {
+export default function useScroll(options = {}) {
+  // Support the old configuration format where
+  // shouldUpdateScroll is the only argument
+  const shouldUpdateScroll = typeof options === 'function' ?
+    options :
+    options.shouldUpdateScroll;
+
+  const updateScroll = options.updateScroll || (cb => cb());
+
   return {
     renderRouterContext: (child, props) => (
       <ScrollBehaviorContext
         shouldUpdateScroll={shouldUpdateScroll}
+        updateScroll={updateScroll}
         routerProps={props}
       >
         {child}


### PR DESCRIPTION
This PR implements the feature requested in #56.

Based on the answer in the issue I understood it as this is not something this library want to manage, and if so please close this PR. I will then instead publish this a fork instead but the best thing would be to get this into this repository, in some form, since it is something that several are requesting and might benefit from.

The implementation is similar to the one that was original accepted in `scroll-behaviour` https://github.com/taion/scroll-behavior/pull/58 and later removed.

This is how it would be used with for example `react-router-redial`.
```jsx
let updateScroll = () => {};

ReactDOM.render(
  <Router
    history={browserHistory}
    routes={routes}
    render={applyRouterMiddleware(
      useScroll({
        updateScroll: (cb) => updateScroll = cb
      }),
      useRedial({
        onCompleted: (type) => type === 'beforeTransition' && updateScroll()
      })
    )}
  />,
  container
);
```
This will make sure we only update the scroll position when we are ready to do so.

I have not implemented any tests yet or updated the README and will wait to do so until I know if this is something that might be merged.

A thing to note here is that I took the liberty to convert the arguments of `useScroll` to an option object to make it little nicer if one needs to only define `updateScroll` but not `shouldUpdateScroll`, however it is still backwards compatible and accepts the current way of configuration. 